### PR TITLE
Fixes react-dom dependency to minor version 16.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "pui-react-animation": "^1.0.2",
     "raf": "^3.1.0",
     "react-addons-shallow-compare": "^15.0.1",
-    "react-dom": "^16.0.0",
+    "react-dom": "~16.2.1",
     "scroll-into-view": "^1.3.0",
     "tether": "^1.3.7",
     "through": "^2.3.8",


### PR DESCRIPTION
It turns out that The nulogy fork of Pivotal UI is not compatible with the latest version of React (16.6 at the time of writing). 

I am fixing this at 16.2 as that is the version currently in use in Nulogy.